### PR TITLE
Add dentist-specific appointments view

### DIFF
--- a/src/components/appointments/AppointmentsPage.jsx
+++ b/src/components/appointments/AppointmentsPage.jsx
@@ -5,7 +5,8 @@ import styles from "./AppointmentsPage.module.css";
 
 const AppointmentsPage = () => {
   const [appointments, setAppointments] = useState([]);
-  const clientId = parseInt(localStorage.getItem("clientId"));
+  const userId = parseInt(localStorage.getItem("clientId"));
+  const role = localStorage.getItem("role");
 
   useEffect(() => {
     getAppointments();
@@ -13,16 +14,16 @@ const AppointmentsPage = () => {
 
   const getAppointments = async () => {
     try {
-      const response = await axios.get(
-        `http://localhost:8080/api/appointments/client/${clientId}`,
-        {
-          headers: {
-            Authorization: localStorage.getItem("token"),
-          },
-        }
-      );
+      const url =
+        role === "DENTIST"
+          ? `http://localhost:8080/api/appointments/dentist/${userId}/pending`
+          : `http://localhost:8080/api/appointments/client/${userId}`;
+      const response = await axios.get(url, {
+        headers: {
+          Authorization: localStorage.getItem("token"),
+        },
+      });
       setAppointments(response.data);
-      console.log(response.data);
     } catch (error) {
       console.error(error);
     }
@@ -44,9 +45,41 @@ const AppointmentsPage = () => {
     }
   };
 
+  const handleAccept = async (appointmentId) => {
+    try {
+      await axios.put(
+        `http://localhost:8080/api/appointments/${appointmentId}/accept`,
+        null,
+        {
+          headers: { Authorization: localStorage.getItem("token") },
+        }
+      );
+      getAppointments();
+    } catch (error) {
+      console.error("Eroare la acceptare:", error);
+    }
+  };
+
+  const handleDecline = async (appointmentId) => {
+    try {
+      await axios.put(
+        `http://localhost:8080/api/appointments/${appointmentId}/decline`,
+        null,
+        {
+          headers: { Authorization: localStorage.getItem("token") },
+        }
+      );
+      getAppointments();
+    } catch (error) {
+      console.error("Eroare la respingere:", error);
+    }
+  };
+
   return (
     <Container className={styles.appointmentsContainer}>
-      <h2 className="mb-4">Programările mele</h2>
+      <h2 className="mb-4">
+        {role === "DENTIST" ? "Programări în așteptare" : "Programările mele"}
+      </h2>
       <ListGroup as="ul">
         {appointments.map((appt) => (
           <ListGroup.Item
@@ -66,22 +99,47 @@ const AppointmentsPage = () => {
               <span>
                 <strong>Descriere:</strong> {appt.description}
               </span>
-              <span>
-                <strong>Dentist:</strong> {appt.dentistName}
-              </span>
+              {role === "DENTIST" ? (
+                <span>
+                  <strong>Client:</strong> {appt.clientName}
+                </span>
+              ) : (
+                <span>
+                  <strong>Dentist:</strong> {appt.dentistName}
+                </span>
+              )}
               <span>
                 <strong> Status: </strong> {appt.status}
               </span>
             </div>
-            {["ACCEPTED", "WAITING"].includes(appt.status) && (
-              <Button
-                variant="outline-danger"
-                size="sm"
-                className={styles.cancelButton}
-                onClick={() => handleCancel(appt.id)}
-              >
-                Anulează
-              </Button>
+            {role === "DENTIST" ? (
+              <div className={styles.actionButtons}>
+                <Button
+                  variant="success"
+                  size="sm"
+                  onClick={() => handleAccept(appt.id)}
+                >
+                  Acceptă
+                </Button>
+                <Button
+                  variant="outline-danger"
+                  size="sm"
+                  onClick={() => handleDecline(appt.id)}
+                >
+                  Respinge
+                </Button>
+              </div>
+            ) : (
+              ["ACCEPTED", "WAITING"].includes(appt.status) && (
+                <Button
+                  variant="outline-danger"
+                  size="sm"
+                  className={styles.cancelButton}
+                  onClick={() => handleCancel(appt.id)}
+                >
+                  Anulează
+                </Button>
+              )
             )}
           </ListGroup.Item>
         ))}

--- a/src/components/appointments/AppointmentsPage.module.css
+++ b/src/components/appointments/AppointmentsPage.module.css
@@ -36,3 +36,8 @@
 .cancelButton {
   flex-shrink: 0;
 }
+
+.actionButtons {
+  display: flex;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- detect user role from local storage
- for dentists load their pending appointments
- add accept/decline handlers and buttons
- show different fields for dentist vs client
- style action buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad74cabe8832180ae2b93c3e04dd7